### PR TITLE
Use MaybeUninit in rusage struct initialization

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -1,35 +1,19 @@
 use crate::PosixTime;
-use libc::{rusage, timespec, c_long, time_t, suseconds_t, timeval};
+use libc::{rusage, timespec, c_long, time_t};
 use std::time::Duration;
+use std::mem::MaybeUninit;
 
 fn get_r_usage() -> Result<Box<rusage>, libc::c_int> {
-    let mut r_usage = rusage {
-        ru_utime: timeval{ tv_sec: 0 as time_t, tv_usec: 0 as suseconds_t, },
-        ru_stime: timeval{ tv_sec: 0 as time_t, tv_usec: 0 as suseconds_t, },
-        ru_maxrss: 0 as c_long,
-        ru_ixrss: 0 as c_long,
-        ru_idrss: 0 as c_long,
-        ru_isrss: 0 as c_long,
-        ru_minflt: 0 as c_long,
-        ru_majflt: 0 as c_long,
-        ru_nswap: 0 as c_long,
-        ru_inblock: 0 as c_long,
-        ru_oublock: 0 as c_long,
-        ru_msgsnd: 0 as c_long,
-        ru_msgrcv: 0 as c_long,
-        ru_nsignals: 0 as c_long,
-        ru_nvcsw: 0 as c_long,
-        ru_nivcsw: 0 as c_long,
-    };
- 
+    let mut r_usage = MaybeUninit::<rusage>::uninit();
+
     let errno = unsafe {
-       libc::getrusage(libc::RUSAGE_SELF, &mut r_usage as *mut rusage)
+       libc::getrusage(libc::RUSAGE_SELF, r_usage.as_mut_ptr())
     };
 
     if errno != 0 {
         Err(errno)
     } else {
-        Ok(Box::new(r_usage))
+        Ok(Box::new(unsafe { r_usage.assume_init() }))
     }
 }
 


### PR DESCRIPTION
struct rusage hase extra fields on some platforms (e.g., when
compiling with MUSL libc to get fully static binaries), which results
in the following error message:

```
error[E0063]: missing field `__reserved` in initializer of `libc::unix::rusage`
 --> src/time.rs:6:23
  |
6 |     let mut r_usage = rusage {
  |                       ^^^^^^ missing `__reserved`

```

As kernel is supposed to fill all the fields in struct rusage, it
is safe to use MaybeUninit instead of specifying initial values of all
the fields.

It also results in shorter, simpler code.

I tested this change with my benchmarks and couldn't find any
regressions.